### PR TITLE
fixt print model only few layers

### DIFF
--- a/maxvit/maxvit.py
+++ b/maxvit/maxvit.py
@@ -672,7 +672,10 @@ class MaxViT(nn.Module):
         Returns:
             output (torch.Tensor): Image features of the backbone.
         """
-
+        # output = input
+        # for stage in self.stages:
+        #     output = stage(output)
+        # return output
         return self.stages(input)
 
     def forward_head(self, input: torch.Tensor, pre_logits: bool = False):
@@ -793,4 +796,6 @@ if __name__ == '__main__':
 
     # test_networks()
     model = max_vit_base_224(num_classes=10)
-    print(model)
+    from torchsummary import summary
+    data = torch.rand(1, 3, 224, 224)
+    summary(model, data, device='cpu')

--- a/maxvit/maxvit.py
+++ b/maxvit/maxvit.py
@@ -80,6 +80,7 @@ class MBConv(nn.Module):
         # Make main path
         self.main_path = nn.Sequential(
             norm_layer(in_channels),
+            nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=(1, 1)),
             DepthwiseSeparableConv(in_chs=in_channels, out_chs=out_channels, stride=2 if downscale else 1,
                                    act_layer=act_layer, norm_layer=norm_layer, drop_path_rate=drop_path),
             SqueezeExcite(in_chs=out_channels, rd_ratio=0.25),
@@ -760,8 +761,8 @@ if __name__ == '__main__':
 
 
     def test_relative_self_attention() -> None:
-        relative_self_attention = RelativeSelfAttention(in_channels=128)
-        input = torch.rand(4, 128, 14 * 14)
+        relative_self_attention = RelativeSelfAttention(in_channels=128, grid_window_size=(14, 14))
+        input = torch.rand(4, 14 * 14, 128)
         output = relative_self_attention(input)
         print(output.shape)
 
@@ -794,8 +795,4 @@ if __name__ == '__main__':
             print(output.shape)
 
 
-    # test_networks()
-    model = max_vit_base_224(num_classes=10)
-    from torchsummary import summary
-    data = torch.rand(1, 3, 224, 224)
-    summary(model, data, device='cpu')
+    test_relative_self_attention()

--- a/maxvit/maxvit.py
+++ b/maxvit/maxvit.py
@@ -634,7 +634,7 @@ class MaxViT(nn.Module):
                     norm_layer_transformer=norm_layer_transformer
                 )
             )
-
+        self.stages = nn.Sequential(*self.stages)
         self.global_pool: str = global_pool
         self.head = nn.Linear(channels[-1], num_classes)
 
@@ -672,10 +672,8 @@ class MaxViT(nn.Module):
         Returns:
             output (torch.Tensor): Image features of the backbone.
         """
-        output = input
-        for stage in self.stages:
-            output = stage(output)
-        return output
+
+        return self.stages(input)
 
     def forward_head(self, input: torch.Tensor, pre_logits: bool = False):
         """ Forward pass of classification head.
@@ -793,4 +791,6 @@ if __name__ == '__main__':
             print(output.shape)
 
 
-    test_networks()
+    # test_networks()
+    model = max_vit_base_224(num_classes=10)
+    print(model)


### PR DESCRIPTION
model = max_vit_base_224(num_classes=10)
print(model)

-----------------------------------------------------------------------------------------------------------

terminal output: 
(stem): Sequential(
  (0): Conv2d(3, 64, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))
  (1): GELU()
  (2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  (3): GELU()
)
(head): Linear(in_features=768, out_features=10, bias=True)
)

----------------------------------------------------------------------------------------------------------
model = max_vit_base_224(num_classes=10)
data = torch.rand(1, 3, 224, 224)
from torchsummary import summary
summary(model, data, device='cpu')

----------------------------------------------------------------------------------------------------------
Layer (type:depth-idx)                   Output Shape              Param #

----------------------------------------------------------------------------------------------------------
├─Sequential: 1-1                        [-1, 64, 112, 112]        --
|    └─Conv2d: 2-1                       [-1, 64, 112, 112]        1,792
|    └─GELU: 2-2                         [-1, 64, 112, 112]        --
|    └─Conv2d: 2-3                       [-1, 64, 112, 112]        36,928
|    └─GELU: 2-4                         [-1, 64, 112, 112]        --
├─Linear: 1-2                            [-1, 10]                  7,690

----------------------------------------------------------------------------------------------------------
Total params: 46,410
Trainable params: 46,410
Non-trainable params: 0
Total mult-adds (M): 484.14

----------------------------------------------------------------------------------------------------------
Input size (MB): 0.57
Forward/backward pass size (MB): 12.25
Params size (MB): 0.18
Estimated Total Size (MB): 13.00

----------------------------------------------------------------------------------------------------------